### PR TITLE
Allowing earliar versions of vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,7 +2,7 @@
 # vi: set ft=ruby :
 
 VAGRANTFILE_API_VERSION = '2'
-Vagrant.require_version ">= 1.7.0"
+Vagrant.require_version ">= 1.6.5"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = 'trusty64'


### PR DESCRIPTION
Vagrant 1.6.5 worked fine on my machine. Therefore adding support for earliar versions.
